### PR TITLE
Update tls.tf

### DIFF
--- a/examples/prereqs_quickstart/tls/tls.tf
+++ b/examples/prereqs_quickstart/tls/tls.tf
@@ -16,7 +16,7 @@ resource "tls_self_signed_cert" "ca" {
   private_key_pem = tls_private_key.ca.private_key_pem
 
   subject {
-    common_name = "vault.server.com"
+    common_name = "ca.vault.server.com"
   }
 
   validity_period_hours = 720 # 30 days


### PR DESCRIPTION
CA CN update avoids OpenSSL errors if it is used to validate the certs: https://stackoverflow.com/a/19738223